### PR TITLE
rename entity_examples -> common_examples

### DIFF
--- a/server.js
+++ b/server.js
@@ -66,8 +66,8 @@ function readData(path) {
       if (!json.rasa_nlu_data) {
         return reject('"rasa_nlu_data" is undefined')
       }
-      if (!json.rasa_nlu_data.entity_examples) {
-        return reject('"rasa_nlu_data.entity_examples" is undefined')
+      if (!json.rasa_nlu_data.common_examples) {
+        return reject('"rasa_nlu_data.common_examples" is undefined')
       }
 
       resolve(json)
@@ -168,7 +168,7 @@ function serve() {
     const data = req.body
     if (!data
       || !data.rasa_nlu_data
-      || !data.rasa_nlu_data.entity_examples
+      || !data.rasa_nlu_data.common_examples
     ) {
       res.json({error: 'file is invalid'})
     }

--- a/src/AddExampleModal.js
+++ b/src/AddExampleModal.js
@@ -12,8 +12,8 @@ const mapState = (state) => ({
   index: state.idxExampleInModal,
   example: state.examples
     && state.examples.rasa_nlu_data
-    && state.examples.rasa_nlu_data.entity_examples
-    && state.examples.rasa_nlu_data.entity_examples[state.idxExampleInModal]
+    && state.examples.rasa_nlu_data.common_examples
+    && state.examples.rasa_nlu_data.common_examples[state.idxExampleInModal]
 })
 
 const mapActions = dispatch => ({

--- a/src/App.js
+++ b/src/App.js
@@ -10,7 +10,7 @@ import { Spin } from 'antd'
 const mapState = (state) => ({
   examples: state.examples
     && state.examples.rasa_nlu_data
-    && state.examples.rasa_nlu_data.entity_examples
+    && state.examples.rasa_nlu_data.common_examples
 })
 
 class App extends Component {

--- a/src/EntityTable.js
+++ b/src/EntityTable.js
@@ -8,7 +8,7 @@ import immutable from 'object-path-immutable'
 
 const mapState = (state, props) => {
   const { index } = props
-  const example = state.examples.rasa_nlu_data.entity_examples[index]
+  const example = state.examples.rasa_nlu_data.common_examples[index]
   const selection = state.selection && state.selection.index === index
     ? state.selection
     : null

--- a/src/ExampleTable.js
+++ b/src/ExampleTable.js
@@ -12,7 +12,7 @@ const mapState = (state) => ({
   expandeds: state.expandeds,
   examples: state.examples
     && state.examples.rasa_nlu_data
-    && state.examples.rasa_nlu_data.entity_examples
+    && state.examples.rasa_nlu_data.common_examples
 })
 
 const mapActions = dispatch => ({

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -37,7 +37,7 @@ export default function reducer (
       const { index, value } = payload
       state = immutable.set(
         state,
-        `examples.rasa_nlu_data.entity_examples.${index}`,
+        `examples.rasa_nlu_data.common_examples.${index}`,
         value,
       )
       return {...state, isUnsaved: true}
@@ -51,7 +51,7 @@ export default function reducer (
       }
       state = immutable.del(
         state,
-        `examples.rasa_nlu_data.entity_examples.${index}`,
+        `examples.rasa_nlu_data.common_examples.${index}`,
       )
       return {...state, isUnsaved: true}
     }
@@ -96,16 +96,16 @@ export default function reducer (
     case OPEN_ADD_MODAL: {
       state = immutable.push(
         state,
-        `examples.rasa_nlu_data.entity_examples`,
+        `examples.rasa_nlu_data.common_examples`,
         {text: '', intent: '', entities: []},
       )
-      const index = state.examples.rasa_nlu_data.entity_examples.length - 1
+      const index = state.examples.rasa_nlu_data.common_examples.length - 1
       return immutable.set(state, `idxExampleInModal`, index)
     }
     case CLOSE_ADD_MODAL: {
       state = immutable.del(
         state,
-        `examples.rasa_nlu_data.entity_examples.${state.idxExampleInModal}`,
+        `examples.rasa_nlu_data.common_examples.${state.idxExampleInModal}`,
       )
       return immutable.set(state, `idxExampleInModal`, null)
     }

--- a/src/testData.json
+++ b/src/testData.json
@@ -1,6 +1,6 @@
 {
   "rasa_nlu_data": {
-    "entity_examples": [
+    "common_examples": [
       {
         "text": "hey",
         "intent": "greet",


### PR DESCRIPTION
create `common_examples` , which are used to train both intents and entities. 

This is poorly documented in rasa NLU at the moment, see also this issue https://github.com/golastmile/rasa_nlu/issues/84 , so we will improve that! 